### PR TITLE
Fixed spelling mistake in parameter

### DIFF
--- a/Adafruit_BMP085_U.h
+++ b/Adafruit_BMP085_U.h
@@ -104,7 +104,7 @@ class Adafruit_BMP085_Unified : public Adafruit_Sensor
     bool  begin(bmp085_mode_t mode = BMP085_MODE_ULTRAHIGHRES);
     void  getTemperature(float *temp);
     void  getPressure(float *pressure);
-    float pressureToAltitude(float seaLvel, float atmospheric);
+    float pressureToAltitude(float seaLevel, float atmospheric);
     float seaLevelForAltitude(float altitude, float atmospheric);
     // Note that the next two functions are just for compatibility with old
     // code that passed the temperature as a third parameter.  A newer


### PR DESCRIPTION
seaLvel -> seaLevel (was correct in `.cpp`-file)

Please enable all compiler warnings and you will be likely finding such mistakes before pushing the code to github...