### PR TITLE
eliminate warnings for unused X1 X2

### DIFF
--- a/Adafruit_BMP085_U.cpp
+++ b/Adafruit_BMP085_U.cpp
@@ -329,7 +329,7 @@ void Adafruit_BMP085_Unified::getPressure(float *pressure)
 /**************************************************************************/
 void Adafruit_BMP085_Unified::getTemperature(float *temp)
 {
-  int32_t UT, X1, X2, B5;     // following ds convention
+  int32_t UT, B5;     // following ds convention
   float t;
 
   readRawTemperature(&UT);


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

This change modifies Adafruit_BMP085_U.cpp to eliminate two unused variables that would appear as red warnings during compiles using the unmodified code.

- **Describe any known limitations with your change.**  

None known.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

It compiles without the warnings for me.

