### PR TITLE
Dependency in library.properties as in BMP280 lib

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Unified sensor driver for Adafruit's BMP085 & BMP180 breakouts
 category=Sensors
 url=https://github.com/adafruit/Adafruit_BMP085_Unified
 architectures=*
+depends=Adafruit Unified Sensor


### PR DESCRIPTION
The Arduino IDE is capable of doing very basic dependency resolution.
This library needs Adafruit Unified Sensor, hence it should be listed as a dependency.
